### PR TITLE
ESX version, map blips, markers to quicklaunch race, shared races

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# FiveM StreetRaces
+ORIGINAL: https://github.com/bepo13/FiveM-StreetRaces
 
+# FiveM StreetRaces
 FiveM resource for street races with custom checkpoints and HUD.
 
 ## Installation
-
 1. Add the StreetRaces folder to your FiveM resources directory
-2. Edit your server.cfg and add "start StreetRaces"
+2. Edit your server.cfg and add "start StreetRaces" (or "ensure StreetRaces")
+
+### Added things
+1. ESX support (credits to nojdh, https://github.com/bepo13/FiveM-StreetRaces/pull/1)
+2. Shared races. Everyone can see, start, edit, delete the races, no longer tied to steam id
+3. Map blips where the races begin (first checkpoint)
+4. Markers at the blips to quick start the races (no need to type /race start -money- -time-)
+5. More configurations: blip color, unique blip names, marker color , quickstart money ammount etc..

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ FiveM resource for street races with custom checkpoints and HUD.
 3. Map blips where the races begin (first checkpoint)
 4. Markers at the blips to quick start the races (no need to type /race start -money- -time-)
 5. More configurations: blip color, unique blip names, marker color , quickstart money ammount etc..
+video: https://www.youtube.com/watch?v=7VLbqP7pa8A

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ FiveM resource for street races with custom checkpoints and HUD.
 3. Map blips where the races begin (first checkpoint)
 4. Markers at the blips to quick start the races (no need to type /race start -money- -time-)
 5. More configurations: blip color, unique blip names, marker color , quickstart money ammount etc..
-video: https://www.youtube.com/watch?v=7VLbqP7pa8A
+6. video: https://www.youtube.com/watch?v=7VLbqP7pa8A

--- a/StreetRaces/config.lua
+++ b/StreetRaces/config.lua
@@ -12,15 +12,15 @@ config_cl = {
     hudPosition = vec(0.015, 0.725),    -- Screen position to draw racing HUD
 
     showBlips = true,                   -- Draw blips on the map for custom races
-    blipColor = 0,                      -- Map blip color
-    blipsUpdateTime = 15000,            -- How often should the client update the blips on the map in milliseconds (dont set it to 0 or a small number, blips will blink or wont even show up)
+    blipColor = 3,                      -- Map blip color
+    blipsUpdateTime = 30000,            -- How often should the client update the blips on the map in milliseconds (dont set it to 0 or a small number, blips will blink or wont even show up)
     uniqueBlipNames = false,            -- True = blip's name will be the name of the race, False = every blip will be called Custom Race and will be grouped together
     quickStartMarkers = true,           -- Spawn quickstart markers on the game world. Press ~INPUT_DETONATE~ (G) to start the race lobby
-    quickStartMarkerColorRed = 255,     -- Quickstart marker color red value
-    quickStartMarkerColorGreen = 255,   -- Quickstart marker color green value
-    quickStartMarkerColorBlue = 0,      -- Quickstart marker color blue value
-    quickStartMoney = 100,              -- Quickstart wager 
-    quickStartReadyUpTime = 15          -- Quickstart race wait time in seconds
+    quickStartMarkerColorRed = 0,       -- Quickstart marker color red value
+    quickStartMarkerColorGreen = 128,   -- Quickstart marker color green value
+    quickStartMarkerColorBlue = 255,    -- Quickstart marker color blue value
+    quickStartMoney = 0,                -- Quickstart wager 
+    quickStartReadyUpTime = 20          -- Quickstart race wait time in seconds
 }
 
 -- SERVER CONFIGURATION

--- a/StreetRaces/config.lua
+++ b/StreetRaces/config.lua
@@ -9,7 +9,18 @@ config_cl = {
     checkpointHeight = 10.0,            -- Height of 3D checkpoints in meters
     checkpointBlipColor = 5,            -- Color of checkpoint map blips and navigation (see SetBlipColour native reference)
     hudEnabled = true,                  -- Enable racing HUD with time and checkpoints
-    hudPosition = vec(0.015, 0.725)     -- Screen position to draw racing HUD
+    hudPosition = vec(0.015, 0.725),    -- Screen position to draw racing HUD
+
+    showBlips = true,                   -- Draw blips on the map for custom races
+    blipColor = 0,                      -- Map blip color
+    blipsUpdateTime = 15000,            -- How often should the client update the blips on the map in milliseconds (dont set it to 0 or a small number, blips will blink or wont even show up)
+    uniqueBlipNames = false,            -- True = blip's name will be the name of the race, False = every blip will be called Custom Race and will be grouped together
+    quickStartMarkers = true,           -- Spawn quickstart markers on the game world. Press ~INPUT_DETONATE~ (G) to start the race lobby
+    quickStartMarkerColorRed = 255,     -- Quickstart marker color red value
+    quickStartMarkerColorGreen = 255,   -- Quickstart marker color green value
+    quickStartMarkerColorBlue = 0,      -- Quickstart marker color blue value
+    quickStartMoney = 100,              -- Quickstart wager 
+    quickStartReadyUpTime = 15          -- Quickstart race wait time in seconds
 }
 
 -- SERVER CONFIGURATION

--- a/StreetRaces/port_sv.lua
+++ b/StreetRaces/port_sv.lua
@@ -1,29 +1,33 @@
+ESX = nil
+TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+
 -- Helper function for getting player money
 function getMoney(source)
-    -- Add framework API's here (return large number by default)
-    return 1000000
+    local xPlayer = ESX.GetPlayerFromId(source)
+    local getmoney = xPlayer.getMoney()
+    return getmoney
 end
 
 -- Helper function for removing player money
 function removeMoney(source, amount)
-    -- Add framework API's here
+    local xPlayer = ESX.GetPlayerFromId(source)
+    xPlayer.removeMoney(amount)
 end
 
 -- Helper function for adding player money
 function addMoney(source, amount)
-    -- Add framework API's here
+    local xPlayer = ESX.GetPlayerFromId(source)
+    xPlayer.addMoney(amount)
 end
 
 -- Helper function for getting player name
 function getName(source)
-    -- Add framework API's here
     return GetPlayerName(source)
 end
 
 -- Helper function for notifying players
 function notifyPlayer(source, msg)
-    -- Add custom notification here (use chat by default)
-    TriggerClientEvent('chatMessage', source, "[StreetRaces]", {255, 0, 0}, msg)
+    TriggerClientEvent('chatMessage', source, "[RACE]", {255,64,64}, msg)
 end
 
 -- Saved player data and file
@@ -44,8 +48,8 @@ function loadPlayerData(source)
     end
 
     -- Get player steamID from source and use as key to get player data
-    local playerId = string.sub(GetPlayerIdentifier(source, 0), 7, -1)
-    local playerData = playersData[playerId]
+    -- local playerId = string.sub(GetPlayerIdentifier(source, 0), 7, -1)
+    local playerData = playersData["all"]
 
     -- Return saved player data
     if playerData == nil then
@@ -68,8 +72,8 @@ function savePlayerData(source, data)
     end
 
     -- Get player steamID from source and use as key to save player data
-    local playerId = string.sub(GetPlayerIdentifier(source, 0), 7, -1)
-    playersData[playerId] = data
+    -- local playerId = string.sub(GetPlayerIdentifier(source, 0), 7, -1)
+    playersData["all"] = data
 
     -- Save file
     local file = io.open(playersDataFile, "w+")

--- a/StreetRaces/races_sv.lua
+++ b/StreetRaces/races_sv.lua
@@ -248,6 +248,6 @@ RegisterNetEvent("StreetRaces:getNewCoordsForBlips_sv")
 AddEventHandler("StreetRaces:getNewCoordsForBlips_sv", function()
     local playerRaces = loadPlayerData(source)
     for name, race in pairs(playerRaces) do
-        TriggerClientEvent("StreetRaces:addBlipToTable", -1, name, race[1].coords.x, race[1].coords.y, race[1].coords.z)
+        TriggerClientEvent("StreetRaces:addBlipToTable", source, name, race[1].coords.x, race[1].coords.y, race[1].coords.z)
     end
 end)

--- a/StreetRaces/races_sv.lua
+++ b/StreetRaces/races_sv.lua
@@ -242,3 +242,12 @@ AddEventHandler("StreetRaces:loadRace_sv", function(name)
         notifyPlayer(source, msg)
     end
 end)
+
+-- Feeding new race blips to the clients
+RegisterNetEvent("StreetRaces:getNewCoordsForBlips_sv")
+AddEventHandler("StreetRaces:getNewCoordsForBlips_sv", function()
+    local playerRaces = loadPlayerData(source)
+    for name, race in pairs(playerRaces) do
+        TriggerClientEvent("StreetRaces:addBlipToTable", -1, name, race[1].coords.x, race[1].coords.y, race[1].coords.z)
+    end
+end)


### PR DESCRIPTION
Added things:
-ESX support (credits to @nojdh, https://github.com/bepo13/FiveM-StreetRaces/pull/1)
-Shared races. Everyone can see, start, edit, delete the races, no longer tied to steam id
-Map blips where the races begin (first checkpoint)
-Markers at the blips to quick start the races (no need to type /race start -money- -time-)
-More configurations: blip color, unique blip names, marker color , quickstart money ammount etc..
-video: https://www.youtube.com/watch?v=7VLbqP7pa8A